### PR TITLE
Fix basic categories of typos

### DIFF
--- a/00-introduction.adoc
+++ b/00-introduction.adoc
@@ -174,7 +174,7 @@ However, even open source projects such as midPoint need funding.
 If you use midPoint in a commercial project that is a source of profit we think it is only fair if you share part of that profit with midPoint authors.
 You know as well as we do that this is needed.
 
-Following people have worked on the words and images that make up this book:
+The following people have worked on the words and images that make up this book:
 
 * Radovan Semančík (author and maintainer)
 * Veronika Kolpaščiková (illustrations, corrections)

--- a/01-idm-intro.adoc
+++ b/01-idm-intro.adoc
@@ -571,7 +571,7 @@ Nobody is going to log in when the AM server fails.
 This obviously means major impact on functionality of all applications.
 Therefore, AM servers need to be highly available and scalable.
 Which is not always an easy task.
-The AM servers need a very careful sizing, as they may easily become a performance bottlenecks.
+The AM servers need a very careful sizing, as they may easily become a performance bottleneck.
 
 However, perhaps the most severe drawback is the total cost of access management solution.
 The cost of the AM server itself is usually not a major issue.
@@ -1270,7 +1270,7 @@ Authorization processing needs to be fast.
 Really fast.
 Even a round-trip across a local network may be a performance killer.
 Due to complexity and performance reasons the authorization mechanisms are often tightly integrated into the fabric of each individual application.
-E.g. it is a common practice that authorization policies are translated to SQL, and they are used as an additional clauses in application-level SQL queries.
+E.g. it is a common practice that authorization policies are translated to SQL, and they are used as additional clauses in application-level SQL queries.
 This technique is taking advantage of the database engine to quickly filter out the data that the user is not authorized to access.
 This method is very efficient, and it is perhaps the only practical option when dealing with large-scale data sets.
 However, this approach is tightly bound to the application data model, and it is usually almost impossible to externalize.
@@ -1580,7 +1580,7 @@ The models are reviewed, versioned and applied in their entirety.
 IDM deployments tend to be complex.
 There are many relations, interactions and policies.
 It is no easy task to predict the effects of a change in a role, policy or organizational structure.
-Therefore, some IDM systems provide a simulation features that provide predictions and impact analyses of planed changes.
+Therefore, some IDM systems provide simulation features that provide predictions and impact analyses of planed changes.
 
 * *Compliance policies*, reporting and management.
 Policies in the identity management world are usually designed to be strictly enforced.
@@ -1681,7 +1681,7 @@ Therefore, there are many overlapping, overloaded and similar terms in use.
 _Identity management_ (IDM) is usually used to describe the low-level parts (technology), while _identity governance_ is used to describe the high-level parts (business).
 Yet the boundary is very fuzzy and many IDM systems provide governance capabilities, and many governance systems provide low-level functions.
 _Identity governance and administration_ (IGA) is a term supposed to describe both parts together.
-_Governance, risk management and compliance (GRC)_ is a terms that was mostly used in the past to represent the high-level identity governance functionality, later known simply as _identity governance_.
+_Governance, risk management and compliance (GRC)_ is a term that was mostly used in the past to represent the high-level identity governance functionality, later known simply as _identity governance_.
 _Identity security_ is a marketing term that roughly covers IGA functionality.
 
 Overall, the terminology is very fluid.
@@ -1973,7 +1973,7 @@ The risk model can evaluate risk of each role.
 This allows detection of anomalies, such as assignment of a powerful high-risk role to an ordinary user that is supposed to be low-risk.
 Such role is likely to be assigned by mistake, or perhaps it was a role assigned during an emergency that was never removed.
 Unassignment of such role may be a quick way to reduce the risk.
-Smart system could suggest several types of such _outliers_, where privileges of an individual users stand out from the surrounding.
+Smart system could suggest several types of such _outliers_, where privileges of individual users stand out from the surrounding.
 
 Once we have the concept of risk established in our system, we can use it in security policies.
 For example, it makes sense to require stronger password for high-risk users, or even better, automatically set up a multi-factor authentication for them.
@@ -2185,7 +2185,7 @@ Therefore, it is crucial to choose and IDM platform that can evolve.
 //Academics and identity experts would probably be happy with the dictionary definition of digital identity.
 //However, the term have got a slightly different meaning when dealing with a broader audience.
 //
-//Generally speaking, the term _digital identity_ is understood as a data records on a person's identity, together with appropriate tools to manage it.
+//Generally speaking, the term _digital identity_ is understood as data records on a person's identity, together with appropriate tools to manage it.
 //This is usually an application that allows to control and manage the identity data by the user.
 //It is the _user-centric_ approach which is usually considered a distinguishing factor between _digital identity_ and other IAM technologies.
 //The basic idea is to keep user in control.

--- a/01-idm-intro.adoc
+++ b/01-idm-intro.adoc
@@ -1537,7 +1537,7 @@ They are triggered automatically, for example as a reaction of re-assigning user
 Similarly to approval processes, some identity governance systems offer "artificial intelligence" support for certification processes.
 Such assistance can be very attractive, as certification campaigns are often quite intimidating due to a large number of decisions that have to be made in each campaign.
 However, the risks of such "automation" is even more pronounced than it is in the approval case.
-Certification is often the last defence against dangerous privilege accumulation.
+Certification is often the last defense against dangerous privilege accumulation.
 Poorly-trained artificial intelligence may cause a systematic build-up of risk in the organization.
 Artificial inteligence support for certification decisions may be very useful.
 However, it is essential to understand how the mechanism works before committing to roll it out for all certifications.
@@ -1635,7 +1635,7 @@ Most techniques seems to be based on recognition of anomalies and patters in the
 _Outlier detection_ mechanisms look for users with privileges that are significantly different from the privileges of their colleagues.
 On the other hand, _role mining_ is used to detect similar privileges assigned to similar users, suggesting new roles.
 Many of the identity analytics and intelligence techniques are based on risk modeling.
-There are mechanisms to _identify over-privileged users_ by analysing risk scores of individual users.
+There are mechanisms to _identify over-privileged users_ by analyzing risk scores of individual users.
 Similar mechanisms can be used to identify high-privilege entitlements assigned to a low-privilege user or similar risk anomalies.
 
 * *Workflow orchestration* is provided by some IGA platforms.
@@ -1965,7 +1965,7 @@ The model is evaluated by the machine, quickly and efficiently.
 The efficiency opens up a whole range of possibilities, that form the essence of a risk-based approach to identity governance.
 
 As we can evaluate a risk posed by any individual user, we can easily identify dangerous accumulation of privileges in the hands of a single user.
-Then we can focus on addressing this risk, analysing why have the privileges accumulated, whether they are all necessary, removing excess privileges to lower the risk.
+Then we can focus on addressing this risk, analyzing why have the privileges accumulated, whether they are all necessary, removing excess privileges to lower the risk.
 Perhaps we can consider changing business processes to divide the responsibilities among several users, lowering the risk even further.
 We can evaluate the risk model after each step, checking whether we have reached acceptable risk levels already.
 
@@ -2061,7 +2061,7 @@ The basic idea is that a system should not implicitly trust any other system, no
 Simply speaking, zero-trust approach is mostly about removing _security perimeter_.
 
 For many decades, corporate networks were designed using _hard exterior, soft interior_ approach.
-Corporate network was protected from the Internet by an army of specialized security systems and techniques, such as firewalls, de-militarized zones, network traffic analysers, intrusion detection systems, network anti-virus scanners and everything else a booming network security market could provide.
+Corporate network was protected from the Internet by an army of specialized security systems and techniques, such as firewalls, de-militarized zones, network traffic analyzers, intrusion detection systems, network anti-virus scanners and everything else a booming network security market could provide.
 While the castle gates were heavily protected, the interior of corporate network was very _soft_.
 Originally, there were no security measures inside corporate networks at all.
 Anyone that got inside could connect to any system.
@@ -2091,7 +2091,7 @@ The concept of zero trust is not new at all.
 It was here pretty much since the very beginnings of information security.
 Security practitioners are trained not to trust anything or anyone, set up policies, require authentication, deny access by default, encrypt all network traffic, minimize privileges, manage risks, and so on.
 Therefore, "zero trust" approach is essentially just a thorough application of proper information security principles.
-This approach is here for decades, it just had different names: defence in depth, perimeterless security, network hardening and so on.
+This approach is here for decades, it just had different names: defense in depth, perimeterless security, network hardening and so on.
 
 Even though zero trust approach is not new, it dramatically gained on importance in the era of cloud services and remote access.
 Many functions provided by traditional corporate applications are provided by cloud services now.

--- a/01-idm-intro.adoc
+++ b/01-idm-intro.adoc
@@ -1039,7 +1039,7 @@ However, it is still a major consideration whether it is worth the trouble of ma
 
 === Identity Provisioning
 
-_Provisioning_, also called _fulfilment_, is perhaps the most frequently used feature in any IDM system.
+_Provisioning_, also called _fulfillment_, is perhaps the most frequently used feature in any IDM system.
 In the generic sense, _provisioning_ means maintenance of user accounts in applications, databases and other target systems.
 This includes creation of the account, various modifications during the account lifetime, and permanent disable or delete at the end of the lifetime.
 The IDM system is using _connectors_ to manipulate the accounts.
@@ -1444,7 +1444,7 @@ Then there are end users that can do almost nothing.
 While this concept may work in small and simple deployments, it is not sufficient for larger systems.
 Large organizations usually need to delegate some administration privileges to other users.
 There may be HR personnel, people that are responsible for management of their organizational units, administrator responsible for a particular group of systems, application administrators, and so on.
-_Delegated administration_ allow delagation of parts of system administration tasks to other users.
+_Delegated administration_ allow delegation of parts of system administration tasks to other users.
 Such delegated privileges are limited in scope.
 For example, HR staff can edit selected attributes on all employees, or project managers can add/remove users in their projects.
 
@@ -2157,7 +2157,7 @@ How is identity management system supposed to even start management of applicati
 Therefore, the effort should start with building such a source, which may be a manually-maintained information in the identity management system.
 Then, application accounts and entitlements (groups) need to be associated with the application.
 Applications much have owners, which can be maintained in IDM system.
-As application accounts and entitlements are associated with an application, they can be automatically de-provissioned when application is decommissioned.
+As application accounts and entitlements are associated with an application, they can be automatically de-provisioned when application is decommissioned.
 However, perhaps the most challenging part is credential management.
 The credentials should be changed periodically.
 However, this change has to be synchronized on both sides of the communication channel (both client and server part), otherwise there will be an outage.

--- a/01-idm-intro.adoc
+++ b/01-idm-intro.adoc
@@ -293,7 +293,7 @@ In such cases the authorization is usually applied to _services_ rather than _ap
 
 However, even applying the authorization to service front-ends does not solve the problem entirely.
 Sophisticated applications often need to make authorization decisions based on context, which is simply not available in the request or user profile at all.
-E.g. an e-banking application may allow or deny a transaction based on the sum of previous transactions that were made earlier that day.
+E.g. an e-banking application may allow or deny a transaction based on the sum of transactions made earlier that day.
 While it may be possible to synchronize all the authorization information into the user profile, it is usually not desirable.
 It would be a major burden to keep such information updated and consistent, not to mention security and privacy concerns.
 Many authorization schemes rely on a specific business logic, which is very difficult to centralize in an authorization server.
@@ -389,7 +389,7 @@ One way or another, the target site now has claims about user identity.
 A local session with the user is usually established at this point to skip the authentication redirects on the next request.
 The target site finally provides the content.
 
-Following table compares the terminology and technologies used in SAML and OIDC worlds.
+The following table compares the terminology and technologies used in SAML and OIDC worlds.
 
 [cols="h,1,1"]
 |===

--- a/03-installation.adoc
+++ b/03-installation.adoc
@@ -71,7 +71,7 @@ MidPoint installation described in this chapter is a very basic one.
 It is ideal for initial exploration of midPoint, development of midPoint configurations, simple testing, demonstrations, exploration and similar purposes.
 It is a very convenient installation, and it provides all you need to get started.
 
-Following steps are applicable to Linux and macOS environment.
+The following steps are applicable to Linux and macOS environment.
 Windows users may use _Docker Desktop_ running on _Windows Subsystem for Linux (WSL)_.
 Please refer to link:https://docs.evolveum.com/midpoint/install/containers/docker/[Evolveum documentation regarding Docker Compose] for more details.
 
@@ -256,7 +256,7 @@ Please use the btn:[Back] buttons that are present in midPoint user interface, o
 == User Interface Areas
 
 MidPoint user interface is quite rich.
-Following list provides short description of the most important parts of the user interface.
+The following list provides short description of the most important parts of the user interface.
 
 * *Home* page gives a brief status about users own accounts, requests, work items and so on.
 This is a page designed to be the first page that will be displayed to the end user after log in to midPoint.

--- a/03-installation.adoc
+++ b/03-installation.adoc
@@ -330,7 +330,7 @@ Users, roles and other object types have their specific color and icon.
 This indicates the object type, and it is used whenever possible: menu, information boxes, lists, box title accents and so on.
 The primary colors and icons are shown in the dashboard:
 
-image::03-03-dashboard-object-types.png[Dashboarad object types]
+image::03-03-dashboard-object-types.png[Dashboard object types]
 
 All user-related controls are red, all controls that deal with organizational structure are yellow.
 Roles are green.

--- a/04-resources-and-mappings.adoc
+++ b/04-resources-and-mappings.adoc
@@ -7,7 +7,7 @@ include::chapter-include.adoc[]
 The pessimist complains about the wind; the optimist expects it to change; the realist adjusts the sails.
 
 Reading and modifying accounts, account attribute synchronization, mapping of attribute values, their transformation using scripts – these are the very basic midPoint features.
-These are _provisioning_ features (or rather _fulfilment_ features as analysts like to have it).
+These are _provisioning_ features (or rather _fulfillment_ features as analysts like to have it).
 These features are absolutely essential for any self-respecting identity management deployment.
 Explaining the very basic mechanisms of identity management deployment is the primary purpose of this chapter.
 It covers the necessary configuration to use midPoint as a _provisioning engine_.
@@ -1150,7 +1150,7 @@ There is a special place in the resource _schema handling_ section for that:
 ----
 
 It is as simple as that.
-Just an empty mapping represented by empty `outbount` element.
+Just an empty mapping represented by empty `outbound` element.
 User has `administrativeStatus` property, account has `administrativeStatus` property, therefore midPoint knows what is the _source_ and _target_ of the mapping.
 We do not need to specify these.
 The values of the `administrativeStatus` property has the same type and meaning on both sides.

--- a/04-resources-and-mappings.adoc
+++ b/04-resources-and-mappings.adoc
@@ -594,7 +594,7 @@ The _kind_ definition tells just that.
 There is also optional _intent_ setting that can be used to define subtypes - but more on that later.
 
 The schema handling section can also be used to augment (or even override) some parts of the resource schema.
-E.g. following example sets a display name for this object type.
+E.g. the following example sets a display name for this object type.
 The display name will be used by the user interface when it displays the account.
 
 [source,xml]
@@ -616,7 +616,7 @@ The display name will be used by the user interface when it displays the account
 ----
 
 However, the most powerful feature that is used in the schema handling is the ability to deal with attributes.
-Following sections are all about that.
+The following sections are all about that.
 
 
 == Attribute Handling
@@ -690,7 +690,7 @@ The mapping specifies that the value of the `cn` attribute will be taken from th
 This a very simple mapping, there is no value transformation, no condition – nothing complicated at all.
 This is how a lot of mappings look like.
 However, mappings can also be very powerful and complex.
-That will be described in next section.
+That will be described in the next section.
 
 .Namespace prefixes `ri` and `icfs`
 TIP: You may have noticed that `ri` and `icfs` namespace prefixes are used in some sample files when referring to object classes or attributes.
@@ -815,7 +815,7 @@ Those examples are still very simple.
 Mappings can do much more – as you will learn in a while.
 However, there is one more thing that we need to explain before going on.
 Mappings are designed to work with more than just a single source.
-Following diagram illustrates a mapping that takes two arguments: _given name_ and _family name_.
+The following diagram illustrates a mapping that takes two arguments: _given name_ and _family name_.
 The mapping produces _full name_ by concatenating these value with a space in between.
 This is the kind of mapping that is frequently used to construct user’s full name from its components.
 While the mapping may seem simple, there are some sophisticated mechanisms hidden inside.
@@ -867,7 +867,7 @@ Sometimes a mapping needs to be really authoritative.
 It has to enforce the value to the target.
 Yet sometimes, we want to provide a default value, and the mapping should never change the target value once it is set.
 Therefore, mapping can be set to various levels of _strength_: from _weak_ to _strong_.
-Following table describes how that works:
+The following table describes how that works:
 
 |===
 |Strength |Description
@@ -978,7 +978,7 @@ As `asIs` is the default expression evaluator, we can save some typing and short
 _Literal_ expression evaluator is used to place a constant value in the target.
 This expression does not need any source at all.
 It always produces the same value.
-Following code sets the attribute `o` to fixed value `ExAmPLE, Inc.`:
+The following code sets the attribute `o` to fixed value `ExAmPLE, Inc.`:
 
 [source,xml]
 ----
@@ -1231,7 +1231,7 @@ See <<92-additional-information.adoc#92-additional-information,Additional Inform
 This section describes a complete working example of connection to the LDAP directory.
 The configuration below is used to automatically create accounts in OpenLDAP server.
 Entire configuration is contained in a single resource definition file.
-Following paragraphs explain individual parts of the file.
+The following paragraphs explain individual parts of the file.
 Simplified XML notation is used for clarity.
 Complete file in a form directly usable in midPoint can be found at the same place as all the other samples in this book
 (see <<92-additional-information.adoc#92-additional-information,Additional Information>> chapter for details).
@@ -1617,7 +1617,7 @@ Shadows record meta-data about resource objects.
 They are used to hold cached values of the attributes (this functionality is still experimental in midPoint {midpointversion}).
 Shadows can be used to hold the state of the resource objects for which midPoint does not have on-line communication channel and the operations are executed manually (a.k.a. "manual resources").
 Therefore, shadows are quite complex objects.
-Following picture provides more substantial example of a shadow.
+The following picture provides more substantial example of a shadow.
 
 image::04-11-user-shadow-resource.png[User-shadow-resource]
 

--- a/05-synchronization.adoc
+++ b/05-synchronization.adoc
@@ -224,10 +224,10 @@ However, midPoint will read data from target system when needed, and it will be 
 == Inbound and Outbound Mappings
 
 MidPoint is firmly based on the principle of reuse.
-Previous chapter explained that behavior of attributes during provisioning is controlled by _mappings_.
+The previous chapter explained that behavior of attributes during provisioning is controlled by _mappings_.
 Therefore, it is perhaps no big surprise that the behavior of attributes during synchronization is also controlled by mappings.
 In fact, provisioning is just a special case of synchronization.
-Following picture explains the combined mechanism.
+The following picture explains the combined mechanism.
 
 image::05-01-sync-source-target.png[Synchronization]
 
@@ -261,7 +261,7 @@ Just the sources and targets are reversed:
 |===
 
 That is it.
-Think about the mappings that were used in previous chapter, just flip the direction.
+Think about the mappings that were used in the previous chapter, just flip the direction.
 Now the mapping will take data from the account and the results will be applied to user object.
 Like this:
 
@@ -736,7 +736,7 @@ E.g. some inbound mappings are evaluated before correlation to provide data for 
 However, generally speaking, the sequence above is what usually happens during inbound synchronization.
 
 When the data are reflected to _user_, the usual midPoint recompute process starts.
-This also includes evaluation of object templates, roles, policies and all the other things that will be covered in following chapters.
+This also includes evaluation of object templates, roles, policies and all the other things that will be covered in the following chapters.
 This is the main part of midPoint processing, internally referred to as "clockwork".
 It is essentially the same processing as if user was modified by an administrator using midPoint user interface.
 
@@ -845,7 +845,7 @@ Reconciliation compares all the data records every time, and it makes any necess
 Even though this method would be perfectly acceptable for a company of this size, we are still going set up a live synchronization task, to make synchronization lighter and faster.
 
 The core of the configuration is contained in a single _resource definition_ file.
-Following paragraphs explain individual parts of the file.
+The following paragraphs explain individual parts of the file.
 There are few additional configuration files for reconciliation and live synchronization _tasks_.
 Simplified XML notation is used for clarity.
 The complete file in a form that is directly usable in midPoint can be found at the same place as all the other samples in this book (see <<92-additional-information.adoc#92-additional-information,Additional Information>> chapter for details).
@@ -899,7 +899,7 @@ The schema handling section contains inbound mappings for HR account attributes:
 
 The schema handling section starts with the usual definitions of _account_ object type.
 This is a definition of `Default account`, using the only object class that our CSV-based HR connector provides.
-We have seen that before, in previous chapter.
+We have seen that before, in the previous chapter.
 However, there is a new part, definition of _focus_.
 The `delineation` and most other parts of schema handling definition refer to _account_ or other _resource_ objects.
 In midPoint parlance those are seen as _projections_, the "spoke" part of hub-and-spoke synchronization topology.
@@ -1662,7 +1662,7 @@ Look for https://docs.evolveum.com/midpoint/reference/expressions/expressions/sc
 
 Only two libraries were mentioned in this section so far.
 However, this is not a whole story.
-A clever reader has certainly figured out that the logging function described in previous section is also a scripting library - and there may be more libraries in the future.
+A clever reader has certainly figured out that the logging function described in the previous section is also a scripting library - and there may be more libraries in the future.
 
 == Resource Capabilities
 
@@ -1775,7 +1775,7 @@ However, when combined with some access control list (ACL) magic, it can work qu
 
 == Synchronization Example: LDAP Account Correlation
 
-Previous example demonstrated the use of synchronization for HR data feed.
+The previous example demonstrated the use of synchronization for HR data feed.
 That is the most obvious use of synchronization mechanisms.
 However, midPoint synchronization can do more tricks than just feeding data to midPoint.
 Synchronization is frequently used even for target resources.
@@ -2456,7 +2456,7 @@ This delta contains a description of modified properties of an existing object.
 As the object can change in a variety of ways, modify delta is the most complex of the three.
 Modify delta contains a list of _item deltas_.
 Each item delta describes how a particular part of an object changes.
-For example, following delta describes that a new value `pirate` is added to a user property `employeeType`.
+For example, the following delta describes that a new value `pirate` is added to a user property `employeeType`.
 
 // TODO: employeeType is obsolete, change example to use something fresher
 
@@ -2570,7 +2570,7 @@ This is a very efficient and flexible method.
 Yet, it is not simple.
 Not many systems support it, and there are often hidden complexities.
 
-Those mechanisms are called _live synchronization strategies_, and they are further explained in following section.
+Those mechanisms are called _live synchronization strategies_, and they are further explained in the following section.
 
 All live synchronization methods need to keep the track of what changes are "recent", i.e. which changes were already processed by midPoint and which were not processed yet.
 There is usually some value that needs to be remembered by midPoint: timestamp of last scan, last sequence number in the change log, serial number of last processed change and so on.
@@ -2699,7 +2699,7 @@ Indeed, there is no security without identity management.
 This is a good start.
 Even if this is all that you do in the first step of the deployment, it is still a major benefit.
 You can get better _visibility_, and with that comes better _security_.
-You have the data to analyze your environment, and plan next step of the identity management deployment.
+You have the data to analyze your environment, and plan the next step of the identity management deployment.
 You won't be blind any longer.
 That is extremely important.
 It is indeed a capital mistake to theorize before one has data.

--- a/05-synchronization.adoc
+++ b/05-synchronization.adoc
@@ -515,7 +515,7 @@ Looking for each individual user one-by-one is not a scalable method, we have to
 Therefore, when choosing a correlation property, make sure it is a searchable (indexed) property.
 
 .Correlation before midPoint 4.6
-NOTE: MidPoint versions before 4.6 used _correlation expressions_, which were basically a search filters parametrized by expressions.
+NOTE: MidPoint versions before 4.6 used _correlation expressions_, which were basically search filters parametrized by expressions.
 This was simple and elegant mechanisms for many years, but it was also quite limited.
 MidPoint 4.6 introduced _smart correlation_ mechanisms, and the old correlation expressions were deprecated.
 
@@ -2144,7 +2144,7 @@ Now we need to tell midPoint to synchronize the values:
                 ...
 ----
 
-A clever readers is now surely wondering whether we have forgotten something.
+A clever reader is now surely wondering whether we have forgotten something.
 We have, indeed.
 Attribute values are synchronized by running reconciliation process.
 However, our outbound mappings will not work in reconciliation.

--- a/05-synchronization.adoc
+++ b/05-synchronization.adoc
@@ -519,7 +519,7 @@ NOTE: MidPoint versions before 4.6 used _correlation expressions_, which were ba
 This was simple and elegant mechanisms for many years, but it was also quite limited.
 MidPoint 4.6 introduced _smart correlation_ mechanisms, and the old correlation expressions were deprecated.
 
-Corrlators are efficient method to automatically link large number of accounts and users.
+Correlators are efficient method to automatically link large number of accounts and users.
 However, correlators rely on reliable and clean data.
 If employee numbers were consistently recorded for every account, correlators can do all the work.
 If usernames were applied consistently across all systems, correlators are going to be a great tool.
@@ -1025,7 +1025,7 @@ However, the mappings do not specify whether the accounts should be created or d
 Mappings control the data, but they do not control the _lifecycle_.
 It is the next configuration section that makes this resource really authoritative:
 
-.ressource-csv-hr.xml
+.resource-csv-hr.xml
 [source,xml]
 ----
             ...
@@ -2028,7 +2028,7 @@ We want midPoint to link the account in this case, therefore we define appropria
                 ...
 ----
 
-_Unliked_ accounts get _linked_.
+_Unlinked_ accounts get _linked_.
 This takes care of accounts for whose we can automatically find an owner by using correlation mechanism.
 What we should do with other accounts?
 We will do nothing about them just yet.
@@ -2112,7 +2112,7 @@ We really want to react to orphaned accounts as soon as possible to reduce any s
 However, it is much better to just _disable_ the account instead of deleting it.
 Some orphaned accounts may have benign reasons.
 The account might have been created by LDAP administrator, because the HR system is temporarily broken and business must go on.
-Detection of orphaned account may also be a false positive, caused by miscofiguration of midPoint correlation mechanism, or simple caused by wrong HR data.
+Detection of orphaned account may also be a false positive, caused by misconfiguration of midPoint correlation mechanism, or simple caused by wrong HR data.
 Re-enabling the account is much less work than re-creating the account, especially if there were already some data stored in the account.
 Even if orphaned account is detected correctly, we still may want to keep it for a while.
 It may provide good material (and evidence) for investigation of possible security incident.

--- a/06-schema.adoc
+++ b/06-schema.adoc
@@ -630,7 +630,7 @@ _Administrative status_ should remain as a "last resort" mechanisms when user ne
 The concepts of lifecycle and activation are not limited to users.
 Many midPoint objects have lifecycle state and activation.
 Roles can expire, organizational units can be disabled and so on.
-Lifecycle and activation are a concepts that have a very broad application in midPoint.
+Lifecycle and activation are concepts that have a very broad application in midPoint.
 Even assignments have activation, which is a crucial element in some configuration (e.g. multi-affiliation).
 Assignments are often used to model employment contracts, student affiliations, service contracts and similar concepts that have time boundaries.
 This is usually achieved by a clever use of assignment activation.

--- a/06-schema.adoc
+++ b/06-schema.adoc
@@ -610,7 +610,7 @@ However, we do not want draft objects to be active yet.
 Such object may need a review and approval to transition to `active` lifecycle state.
 Only then it will really become active.
 
-If lifecycle state indicates object as _active_, the the _activation_ part is considered.
+If lifecycle state indicates object as _active_, the _activation_ part is considered.
 Administrative status, validity dates and lockout status are computed, which determines state of the object.
 
 This may look complicated.

--- a/06-schema.adoc
+++ b/06-schema.adoc
@@ -291,7 +291,7 @@ _Deprecated_ items are not shown at all.
 Only some _operational_ properties are shown.
 Some items are simplified or entirely omitted for clarity.
 
-Following example illustrates the use of midPoint `UserType` schema:
+The following example illustrates the use of midPoint `UserType` schema:
 
 [source,xml]
 ----
@@ -377,13 +377,13 @@ Employees do not work for ever, they may resign, may be laid off, or retired.
 Even then, a record of a former employee may be kept for some time.
 
 While the details of the lifecycle may be subtly different for various organizations and types of objects, the basic outline is almost always the same.
-For that reason the basic lifecycle states are pre-configured in midPoint, as illustrated in following diagram.
+For that reason the basic lifecycle states are pre-configured in midPoint, as illustrated in the following diagram.
 
 image::06-01-lifecycle-statechart.png[Lifecycle states]
 
 Objects have their lifecycle state specified in `lifecycleState` property.
 If no explicit value is specified, the default value is `active`.
-Pre-defined lifecycle states are described in following table.
+Pre-defined lifecycle states are described in the following table.
 
 [%autowidth]
 |===
@@ -499,7 +499,7 @@ _Activation_ also provides ability for manual overrides by administrator in case
 
 The _activation_ in itself is multi-dimensional and a bit complex data structure.
 It is composed of several properties that may change in somehow independent and somehow inter-dependent way.
-Following list provides a quick summary of activation properties:
+The following list provides a quick summary of activation properties:
 
 * *Administrative status* defines administrative state of the object, usually manually set by system administrator.
 
@@ -1273,7 +1273,7 @@ MidPoint type hierarchy was evolving during midPoint development, and now it for
 
 image::06-02-type-hierarchy.png[Type hierarchy]
 
-Following table is summarizing midPoint data types and their purpose.
+The following table is summarizing midPoint data types and their purpose.
 
 |===
 |Data type |Description

--- a/06-schema.adoc
+++ b/06-schema.adoc
@@ -188,7 +188,7 @@ The specific meaning and form of this property is deployment-specific.
 |property
 |Indicates user's preferred language, usually for the purpose of localizing user interfaces.
 The format is IETF language tag defined in BCP 47, where underscore is used as a subtag separator.
-This is usually a ISO 639-1 two-letter language code optionally followed by ISO 3166-1 two-letter country code separated by underscore. +
+This is usually an ISO 639-1 two-letter language code optionally followed by an ISO 3166-1 two-letter country code separated by underscore. +
 Example: `en_US`
 
 |`locale`

--- a/07-rbac.adoc
+++ b/07-rbac.adoc
@@ -784,10 +784,10 @@ As _assignment_ and _inducement_ are in fact the same data structure, similar ap
 <role>
     <name>Marketing Research Undersecretary</name>
     ...
-    <indudement>...</indudement>
-    <indudement>...</indudement>
+    <inducement>...</inducement>
+    <inducement>...</inducement>
     ...
-    <indudement>
+    <inducement>
         <description>
             Employee access to the lab is disabled because the lab burned down
             during an ugly accident. Will be re-enabled when the lab is rebuilt.

--- a/07-rbac.adoc
+++ b/07-rbac.adoc
@@ -39,7 +39,7 @@ However, we will start small.
 We begin with simple scenarios, building our way up.
 This chapter describes basic midPoint RBAC mechanism.
 It provides enough information to start with the usual role-based approach.
-Following chapters will build on that, describing more and more advanced use of the RBAC mechanism.
+The following chapters will build on that, describing more and more advanced use of the RBAC mechanism.
 
 .Terminology
 NOTE: The term _RBAC_ is many things to many people.
@@ -51,7 +51,7 @@ As you will see later, such deviation is really necessary.
 
 == Reality vs Policy
 
-Previous chapters were focused on account provisioning and synchronization.
+The previous chapters were focused on account provisioning and synchronization.
 Their primary focus was an _account_ (or a similar resource object).
 This is what we call _reality_ in midPoint way of thinking.
 Accounts are objects that exist in the databases and files on the resources.
@@ -141,7 +141,7 @@ This may look like a very complicated method to do something simple.
 However, this kind of thinking is really necessary to handle complex cases.
 There may be several assignments that mandate the same account.
 There may be assignments for the same accounts, but each assignment mandates different attributes or values.
-The account that the assignments mandate may exist already, e.g. it may be linked by previous reconciliation with the resource.
+The account that the assignments mandate may exist already, e.g. it may be linked by the previous reconciliation with the resource.
 There may be several accounts for the same user on the same resource (e.g. "ordinary" account and "testing" account).
 And so on.
 We will deal with various cases in this book.

--- a/07-rbac.adoc
+++ b/07-rbac.adoc
@@ -170,7 +170,7 @@ Yet, as all midPoint objects, role has a very familiar structure:
 <role oid="aaa6cde4-0471-11e9-9b50-c743da469067">
     <name>Business analyst</name>
     ...
-</user>
+</role>
 ----
 
 Role object has its _object identifier (OID)_ and _name_.
@@ -219,7 +219,7 @@ Therefore, a `Business Analyst` role may look like this:
              <kind>account</kind>
         </construction>
     </inducement>
-</user>
+</role>
 ----
 
 The usual case is that every employee need to have basic access to company functionality.
@@ -798,7 +798,7 @@ As _assignment_ and _inducement_ are in fact the same data structure, similar ap
             <administrativeStatus>disabled</administrativeStatus>
         </activation>
     </inducement>
-</user>
+</role>
 ----
 
 Many types and variants of assignments can be combined in a single user.
@@ -909,7 +909,7 @@ The roles need to be a bit smarter to use the `teamName` parameter:
              </attribute>
         </construction>
     </inducement>
-</user>
+</role>
 ----
 
 Resulting LDAP account looks like this:

--- a/07-rbac.adoc
+++ b/07-rbac.adoc
@@ -525,7 +525,7 @@ There are many ways how a role hierarchy can be structured.
 One way is to create all roles as "end user" roles that are supposed to be directly assigned to user.
 The clerk-supervisor example above is that case.
 The low-level roles (e.g. `Clerk`) should contain all the privileges necessary for that role to function in an organization, such as all the necessary access to all the applications, networks, services and devices.
-Then combine the elemental roles into a bigger roles, combining business responsibilities as needed.
+Then combine the elemental roles into bigger roles, combining business responsibilities as needed.
 Repeat the process until the entire access control landscape is covered with beautiful roles.
 
 That is the theory.
@@ -1001,7 +1001,7 @@ Such automated approach never really works in practice.
 
 First problem is at the very start: HR data are almost never correct.
 There is very little motivation for the HR data to be completely correct.
-It is not a big issues if someone has a wrong job code or organizational unit code in the HR system.
+It is not a big issue if someone has a wrong job code or organizational unit code in the HR system.
 The business goes on, the salary is paid, everybody is happy.
 There is no efficient feedback loop that would force corrections in HR data - until the identity management system is deployed, that is.
 It takes years or even decades for a typical company to deploy an identity management system.
@@ -1099,10 +1099,10 @@ There can be any complex algorithm in the expression, even a complete ABAC/PBAC 
 At least in theory.
 MidPoint expressions do not make access control decisions, because it is not the job of an identity management system to make such decisions.
 Identity management system should set up the account.
-It provides the "material" for an authorization system to make a correct decisions.
+It provides the "material" for an authorization system to make a correct decision.
 Therefore, midPoint goes as close to ABAC/PBAC as a provisioning system can go.
 In an extreme case the entire ABAC/PBAC policy can be implemented in outbound expressions in resource definition.
-Yet, there are a good reasons nobody does that.
+Yet, there are some good reasons nobody does that.
 
 Dividing the policy into smaller parts brings substantial advantage.
 Therefore, many midPoint deployments are very RBAC-like.

--- a/08-archetypes.adoc
+++ b/08-archetypes.adoc
@@ -168,7 +168,7 @@ Overall, archetypes are to the core of every midPoint deployment.
 
 == Structural vs Auxiliary
 
-An object can have more than one archetype, as long as following rules are followed:
+An object can have more than one archetype, as long as the following rules are followed:
 
 * At most one *structural archetype* can be applied to object.
 Structural archetype provides _structure_ to the object, it specifies icon, color, and presentation of the object.
@@ -197,7 +197,7 @@ Definition of _auxiliary_ archetypes is almost the same as definition of _struct
 NOTE: User interface support for auxiliary archetypes is quite limited in midPoint 4.8.
 This is the reason auxiliary archetypes are not used often in midPoint 4.8.
 In fact, use of birthright _roles_ is still recommended in midPoint 4.8, instead of using auxiliary archetypes such as `Employee`.
-More on that in next chapter.
+More on that in the next chapter.
 
 // TODO: later: how are structural/auxiliary icons and colors combined?
 
@@ -205,7 +205,7 @@ More on that in next chapter.
 
 Archetypes are very useful mechanism for setting up presentation of behaviour of objects.
 Therefore, midPoint contains a set of pre-defined archetypes, ready to be used.
-Following table describes the most interesting pre-configured archetypes:
+The following table describes the most interesting pre-configured archetypes:
 
 |===
 |Archetype |Holder type |Description
@@ -247,7 +247,7 @@ Archetypes influence many aspects of "life" for midPoint objects.
 Therefore, it is a best practice to set proper archetype for object as soon as the object is created.
 This approach makes it easier to customize behavior of objects later on.
 For this reason, we have set `Person` archetype for all users created by synchronization from HR system.
-This is going to be very useful, as we will see in next chapter dealing with object templates.
+This is going to be very useful, as we will see in the chapter dealing with object templates.
 Similarly, it is recommended to properly set archetypes for new roles, services, orgs and other objects.
 
 Choosing the right archetypes is quite important, as change of (structural) archetypes is a serious matter.

--- a/08-archetypes.adoc
+++ b/08-archetypes.adoc
@@ -203,7 +203,7 @@ More on that in the next chapter.
 
 == Pre-configured Archetypes
 
-Archetypes are very useful mechanism for setting up presentation of behaviour of objects.
+Archetypes are very useful mechanism for setting up presentation of behavior of objects.
 Therefore, midPoint contains a set of pre-defined archetypes, ready to be used.
 The following table describes the most interesting pre-configured archetypes:
 

--- a/08-archetypes.adoc
+++ b/08-archetypes.adoc
@@ -364,7 +364,7 @@ Archetypes are a prime example of meta-roles.
             that should be applied to all business roles.
         -->
     </inducement>
-</role>
+</archetype>
 ----
 
 Statements in the _inducement_ above are applied to business _roles_, as opposed to ordinary role where inducements are applied to _users_.

--- a/09-focus-processing.adoc
+++ b/09-focus-processing.adoc
@@ -779,7 +779,7 @@ The reason is that different data types are being compared.
 The `locality` property is polystring, while `‘kitchen’` is a string literal.
 Polystring and string are never equal regardless for their content.
 Therefore, this form of the expression is wrong.
-Following forms may be used instead:
+The following forms may be used instead:
 
 [source,groovy]
 ----
@@ -1132,7 +1132,7 @@ Iteration one happens after the first conflict.
 * `iterationToken` variable contains a string that is derived from the iteration number.
 
 There is default algorithm that derives iteration tokens from iteration number.
-The algorithm is illustrated in following table.
+The algorithm is illustrated in the following table.
 
 |===
 |Iteration |The value of `iteration` variable |The value of `iterationToken` variable
@@ -1760,7 +1760,7 @@ Similarly to the mappings, iteration specification is already part of default `P
 
 As soon as the above configuration is in place, we can start testing our little deployment.
 Go ahead and import the HR resource, import object template, set the object template in the configuration and do not forget to replace the HR CSV file.
-If you did any experiments with previous configuration, it can be helpful to clean up midPoint by using the "delete all identities" process (that little dropdown button in menu:Repository objects[] page).
+If you did any experiments with the previous configuration, it can be helpful to clean up midPoint by using the "delete all identities" process (that little dropdown button in menu:Repository objects[] page).
 When everything is set up, you can try to manually import a single account from the HR resource by using the btn:import[] button, located on the page where you can list resource accounts.
 Once the basic configuration works, you can test username generator by adding Albert Anderson to the HR CSV file and importing the account.
 Do not forget to explicitly fetch the accounts from the resource by clicking on the btn:Reload[] button on the bottom of the page.
@@ -1980,7 +1980,7 @@ So far we have tackled the inbound phase and focus policy phase.
 However, we have not talked about the outbound (provisioning) phase much.
 Now it is the right time to have a look at that.
 
-We are going to reuse the LDAP and CRM resources from previous chapters.
+We are going to reuse the LDAP and CRM resources from the previous chapters.
 Those resources are used here in a pretty much unchanged form.
 There is no need to change them.
 Outbound mappings in the resource definitions specify the basic framework of the account.
@@ -2128,4 +2128,4 @@ If you get to dead end, just scrap everything and start over, or maybe rework ev
 MidPoint is designed for this.
 Evolutionary approach is deeply embedded in midPoint philosophy and design.
 Just go ahead, have fun, conduct experiments and explore.
-Such experience will help a lot when you get back and read through following chapters.
+Such experience will help a lot when you get back and read through the following chapters.

--- a/09-focus-processing.adoc
+++ b/09-focus-processing.adoc
@@ -837,7 +837,7 @@ It has to be explicitly enabled in system configuration:
 </systemConfiguration>
 ----
 
-There is one more significant drawback of role autoassingment, which is quite obvious.
+There is one more significant drawback of role autoassignment, which is quite obvious.
 The autoassignment mapping needs to be in every role.
 There is no way to use this mechanism to handle autoassignment of many roles with just one mapping.
 However, object template mappings can do that easily.
@@ -2098,7 +2098,7 @@ We have running system:
 image::09-04-users-final.png[Users]
 
 Users are imported from the HR system.
-Roles are assigned, which can be checked by navigating to user details page and opening the menu:Assignements[] tab.
+Roles are assigned, which can be checked by navigating to user details page and opening the menu:Assignments[] tab.
 Accounts are provisioned according to the roles, which is the reason for variations in number of accounts for individual users.
 The basic stuff works now.
 Go ahead and try it out, add more roles and mappings, modify the configuration.

--- a/09-focus-processing.adoc
+++ b/09-focus-processing.adoc
@@ -691,7 +691,7 @@ Evaluation of the expression with _old_ value `S007` produces assignment for `Sa
 MidPoint knows that value `S007` was _removed_, therefore it also removes assignment of `Sales Agent` role from the user.
 
 When it comes to security, automatic _unassignment_ of roles is even more important than automatic _assignment_.
-Principle of least privilege dictates that a users should have minimal access rights necessary for conducting their duties.
+Principle of least privilege dictates that users should have minimal access rights necessary for conducting their duties.
 MidPoint _autoassignment_ mechanism take care of that, applying a rule to _assign_ a role when it is necessary, while also using the same rule to _unassign_ the role when it is no longer necessary.
 This mechanism is one of the building block of policy-driven RBAC mechanism, a dynamic role-based access control model which is a native part of midPoint.
 

--- a/10-orgstruct.adoc
+++ b/10-orgstruct.adoc
@@ -780,7 +780,7 @@ If no other relation is specified, this relation is used.
 
 |`manager`
 |Orgs
-|Manager of an organizational unit, project manager, teamleader, etc.
+|Manager of an organizational unit, project manager, team leader, etc.
 Usually entitles a person (or a group) that have leading position in an org.
 This usually specifies executive or operational privileges (cf. `owner`).
 
@@ -874,7 +874,7 @@ The following example of `Project` archetype is using `holderType` clause of the
 The `assignmentRelation` constraints ability to create assignment to the `Project` archetype, in this case the _holder_ of the assignment must be of `OrgType` type.
 However, _assignment relation_ can be used to further constraint use of assignments.
 We probably want to constraint the _relations_ that can be applied to a project.
-It is quite resonable to constraint the relations to members, managers and owners of projects.
+It is quite reasonable to constraint the relations to members, managers and owners of projects.
 This can simplify things, as we probably do to want approvers and "meta" as a relations to projects.
 Also, we want to put only _users_ in the project.
 In theory, midPoint organizational structure can hold almost any type of object.
@@ -905,7 +905,7 @@ Unlike the `holderType` case above, in this case the `assignmentRelation` is pla
 In the previous case, we were constraining assignment of _projects_ to _archetypes_.
 Whereas in this case we are trying to constraint assignments of _users_ to the _projects_.
 This is one degree of indirection farther, therefore _inducement_ is used instead of _assignment_.
-The arechetype acts as a meta-role, the content of the inducement is applied to the _projects_ (archetyped objects), not to the archetype itself.
+The archetype acts as a meta-role, the content of the inducement is applied to the _projects_ (archetyped objects), not to the archetype itself.
 
 The _assignment relation_ specification is used by the user interface.
 User interface is going to present only those object types and relation that make sense for the operation that user has initiated.
@@ -1414,7 +1414,7 @@ The result is that we need two inbound mappings for the `orgnum` attribute:
 ----
 
 Storing original organizational unit identifier in the `identifier` property makes it easier to correlate organizational units.
-The `idenfier` property can be used by the correlators.
+The `identifier` property can be used by the correlators.
 If the identifier is reasonably persistent, this is a huge benefit.
 
 Changes in organizational structure can be quite nasty.
@@ -1806,7 +1806,7 @@ All we need to do now is to re-run the synchronization task.
 The result is a nice organizational structure in LDAP directory:
 
 .Organizational structure in LDAP
-image::10-13-ldap-org-tree.png[Organizational strucutre in LDAP]
+image::10-13-ldap-org-tree.png[Organizational structure in LDAP]
 
 This is a nice result.
 However, there are still several remarks to make.

--- a/10-orgstruct.adoc
+++ b/10-orgstruct.adoc
@@ -391,7 +391,7 @@ This has to come later when the basic principles have enough time to sink in.
 
 .Org and role hierarchies
 NOTE: Both orgs are roles are _hierarchical_ in a way.
-However, they form a separate hierarchies.
+However, they form separate hierarchies.
 Org hierarchy is used to model organizational trees.
 Role hierarchy is used to build access control structures.
 Those hierarchies have completely different purpose.
@@ -484,7 +484,7 @@ Which is usually done by using _archetypes_.
 There are two organizational structures now.
 You can have three organizational structures if you want to, or five of them.
 Any number you like - as long as all the tabs for organizational structures fit on the screen.
-The structures can be a deep trees with many branches, or they can be completely flat, with just a single level.
+The structures can be deep trees with many branches, or they can be completely flat, with just a single level.
 The structure may not even be a tree.
 As long as it is an _acyclic directed graph_ it will work just fine.
 It can have multiple roots, it may have alternate paths, it can do all the crazy stuff.
@@ -716,7 +716,7 @@ The `orderConstraint` data structure in our example looks suspiciously complex.
 That impression is correct, as it indeed is quite a complex concept.
 What we see here is the first glimpse at high-order "assignment algebra" that is a work-horse of complex midPoint deployments.
 This mechanism is often employed when working with _meta-roles_ and _archetypes_.
-As organizational units are _abstract roles_, and organizational structures are just a trees formed by _assignments_, they technically form meta-role structures.
+As organizational units are _abstract roles_, and organizational structures are just trees formed by _assignments_, they technically form meta-role structures.
 
 Therefore, the right way to set up manager privileges is to move privilege definition to a central place.
 It may be top-level root org, or it may be an `Organizational unit` _archetype_.

--- a/10-orgstruct.adoc
+++ b/10-orgstruct.adoc
@@ -378,7 +378,7 @@ For example, this is how we can "inherit" the CRM privileges in _Indirect Sales 
     <inducement>
         <!-- Inducement to parent organizational unit. This creates "inheritance" of privileges. -->
         <targetRef oid="7a1feb50-471f-11ea-8aab-1b2627541f15" type="OrgType"/>
-    </assignment>
+    </inducement>
 </org>
 ----
 
@@ -1910,7 +1910,7 @@ In this case, we would use explicit _kind_ and _intent_ in the construction:
             <intent>admin</intent>
         </construction>
     </inducement>
-</user>
+</role>
 ----
 
 The `System Administrator` role above specifies that a special `admin` account should be created for system administrators.

--- a/10-orgstruct.adoc
+++ b/10-orgstruct.adoc
@@ -422,7 +422,7 @@ There are many trees that make a forrest of organizational structures.
 Fortunately, midPoint is not very picky when it comes to organizational structures.
 MidPoint is not limited to a single organizational tree.
 You can have as many organizational trees as you like.
-You can have functional organizational tree, as we have seen in previous sections.
+You can have functional organizational tree, as we have seen in the previous sections.
 Then you can have independent project organizational structure.
 Just create new root _org_ for projects and place the projects under it:
 
@@ -824,7 +824,7 @@ They just specify how one object relates to another object.
 There are no strict _policies_ or _behavior_ associated with them.
 
 The policies are specified elsewhere.
-Assignments and inducements may behave differently for different relations, as we have seen in previous section.
+Assignments and inducements may behave differently for different relations, as we have seen in the previous section.
 Similarly, _policy rules_ are often sensitive to relations.
 For example, the policy that assignment of some roles has to be approved is implemented by a policy rule that is aware of `approver` relation.
 Authorizations are often sensitive to relations.
@@ -853,7 +853,7 @@ As midPoint deployment matures, it is more than desired to constraint the use of
 _Assignment relation_ mechanism is used for that purpose.
 We have already seen basic usage of assignment relation in archetypes.
 The assignment relation was used to constraint object type that an archetype can be assigned to.
-Following example of `Project` archetype is using `holderType` clause of the `assignmentRelation` to limit application of archetype to orgs.
+The following example of `Project` archetype is using `holderType` clause of the `assignmentRelation` to limit application of archetype to orgs.
 
 .archetype-project.xml
 [source,xml]
@@ -1841,7 +1841,7 @@ You can thank us later.
 
 Synchronization of an organizational structure is an application of a _generic synchronization_ principle.
 Almost any _resource object_ can be synchronized with almost any _midPoint object_ - and vice versa.
-Principle of the synchronization is essentially the same as in user-account case, as we have seen in previous chapters.
+Principle of the synchronization is essentially the same as in user-account case, as we have seen in the previous chapters.
 In that case, the _accounts_ were linked to _user_, midPoint synchronized the data from account to user and from user to accounts.
 The synchronization follows user-account _links_.
 

--- a/10-orgstruct.adoc
+++ b/10-orgstruct.adoc
@@ -1865,7 +1865,7 @@ Therefore, we have decided to use _focus_ and _projection_ terms:
 image::10-15-focus-projections.png[Focus and projections]
 
 The object that is "in the middle" is called _focus_ or _focal object_.
-It is in the centre of the synchronization, it is its focal point.
+It is in the center of the synchronization, it is its focal point.
 Every relevant piece of data is reflected onto the focal object by the synchronization mechanisms.
 
 _User_ is a very typical focal object.

--- a/11-authorizations.adoc
+++ b/11-authorizations.adoc
@@ -18,7 +18,7 @@ We do not want any user to see a list of all the data of all the other users,
 and we definitely do not want any user to modify the data.
 As pretty much any other information system, midPoint needs an ability to deliberately limit access to data stored in its repository.
 However, as midPoint is an identity management platform, the requirements for access control to data are quite demanding.
-For example, following scenarios are quite common in identity and access management world:
+For example, the following scenarios are quite common in identity and access management world:
 
 * Allow any user to see its own user profile, allow editing selected set of properties.
 A user can see significant part of _own_ user profile.

--- a/11-authorizations.adoc
+++ b/11-authorizations.adoc
@@ -139,7 +139,7 @@ While extending the authorization a bit, the result looks like follows in XML no
 
 TODO: many subjects, using a filter -> maintainer of all projects (all subnodes of Projects top node (832e37e4-edfd-11ea-9f8c-ef736d6646a2))
 
-TODO: giving abiliy to add and delete projects as well.
+TODO: giving ability to add and delete projects as well.
 
 TODO: NOTE: orgRef may be too powerful. It grants transitive rights. Use with care. Good for simple delegated administration, but not for fine-grain control. Use filters instead.
 

--- a/12-entitlements.adoc
+++ b/12-entitlements.adoc
@@ -28,7 +28,7 @@ Simply speaking, metaroles are roles applied to other roles.
 Ordinary role applies its characteristics to a user.
 Metarole applies its characteristics to another role.
 This is perfectly possible in midPoint, as role can be applied to almost any midPoint object.
-Then why not apply a role to a another role?
+Then why not apply a role to another role?
 This may seem like a pretty useless exercise, but the truth is that metaroles are tremendously useful.
 
 History is repeating, they say.

--- a/88-deployment.adoc
+++ b/88-deployment.adoc
@@ -19,7 +19,7 @@ It will take years. Plan ahead.
 Just the intro. More details about the entire cycle in the next chapter.
 
 TODO: IDM projects take a long time, split to iterations
-TODO: Analyse, plan, prototype, execute, learn, repeat.
+TODO: Analyze, plan, prototype, execute, learn, repeat.
 
 TODO: midPoint is built to support this approach, including open source (zero up-front license cost, subscriptions)
 

--- a/88-deployment.adoc
+++ b/88-deployment.adoc
@@ -660,7 +660,7 @@ Anyone can provide midPoint-related services, and Evolveum has no power to do an
 Yes, Evolveum maintains a partner network, there are partner levels, marketing channels and all that usual commercial stuff.
 However, those are more-or-less just recommendations.
 We recommend that you engage one of Evolveum partners, companies that demonstrated ability to deliver midPoint-based solutions.
-However, if you choose to employ your local open source enthusiast to work on your midPoint deployment there is nothing to stop you - as long as an appropriate levels of professionally and expertise are maintained.
+However, if you choose to employ your local open source enthusiast to work on your midPoint deployment there is nothing to stop you - as long as appropriate levels of professionally and expertise are maintained.
 There is no warranty to void, because in fact, there are no warranties in the software world anyway.
 There are no contracts to break, as the support contracts do not mandate exclusivity.
 There are no copyrights to violate, as all midPoint source code is out there, as is all the documentation.
@@ -764,7 +764,7 @@ However, it is likely that a more sophisticated approach may be needed to feed s
 
 For example, midPoint identity analytic functionality is designed to analyze usage and structure of roles, or point out roles without owners.
 Future functionality might be used to locate users with risky or unusual access rights.
-However, midPoint should not be used to compute average number of persons in an organizational units, or estimate typical fluctuation of organization unit managers.
+However, midPoint should not be used to compute average number of persons in organizational units, or estimate typical fluctuation of organization unit managers.
 That is a responsibility of business intelligence system, even though such reports may be based on data provided by midPoint.
 
 

--- a/88-deployment.adoc
+++ b/88-deployment.adoc
@@ -800,7 +800,7 @@ Direct access to audit database table is usually used to transfer event informat
 
 === Summary of Boundaries
 
-Following table provides summary and clarification of border cases, specifying functionality provided by IGA plarform _vis-à-vis_ functionality of other systems.
+The following table provides summary and clarification of border cases, specifying functionality provided by IGA plarform _vis-à-vis_ functionality of other systems.
 
 |===
 | MidPoint functionality | Functionality of other systems

--- a/88-deployment.adoc
+++ b/88-deployment.adoc
@@ -364,7 +364,7 @@ Applicability of role management/RBAC varies.
 RBAC is a huge benefit in organizations with regular structures.
 For example, branch offices of a bank usually have just a handful of work positions with well-defined responsibilities (teller, supervisor, branch manager).
 Similarly helpdesk departments, manufacturing floors and similar organizations are usually easy to describe using roles.
-However, when it comes to the same organizations, there are parts of organizational structure that are very hard to decribe using roles.
+However, when it comes to the same organizations, there are parts of organizational structure that are very hard to describe using roles.
 While bank branches are regular, the HQ office is usually completely irregular.
 Almost every person working for HQ has mixed responsibilities, unique combination of privileges and so on.
 This does not mean that you should not try to apply roles in such environment.
@@ -419,7 +419,7 @@ Separate the problem into two parts:
 
 Choose the right level of abstraction.
 The "entitlements" should have a business meaning, rather than technological meaning.
-Such as job, work position, bussiness function, responsibility, ability for meaningful action.
+Such as job, work position, business function, responsibility, ability for meaningful action.
 E.g. "branch supervisor" rather than "access-list-123"
 
 TODO: clean up your entitlements in the target system.
@@ -433,7 +433,7 @@ Synchronize application information from authoritative source.
 
 Management of application accounts, lifecycle, password/key change.
 
-Application decomissioning, removing application groups when application is gone.
+Application decommissioning, removing application groups when application is gone.
 
 However, most organizations are not ready for this.
 
@@ -459,7 +459,7 @@ TODO: usually the last defense against role accumulation
 TODO: laborious process, has to be distributed
 
 Beware of AI.
-It is especially dangerous for certificatin campaigns, as they are usually the last defense against privilege accumulation.
+It is especially dangerous for certification campaigns, as they are usually the last defense against privilege accumulation.
 If you use AI for re-certification, you will need to have automated risk management in place, to provide additional layer of defense.
 
 The best approach is to keep the amount of re-certification to a minimum.
@@ -500,7 +500,7 @@ TODO
 == Bad Practices
 
 * Assuming that all the systems will be fully compliant with standards.
-E.g. there is pracically no LDAP server deployment that is fully compliant with LDAP standard (see LDAP Survival Guide).
+E.g. there is practically no LDAP server deployment that is fully compliant with LDAP standard (see LDAP Survival Guide).
 
 * TODO: user-user manager relation as bad practice. Use orgtree instead.
 
@@ -509,7 +509,7 @@ E.g. there is pracically no LDAP server deployment that is fully compliant with 
 
 Application inventory
 
-Onboarding/offboarding porcesses (joiner-mover-leaver).
+Onboarding/offboarding processes (joiner-mover-leaver).
 
 Processes: Contrary to the popular opinion, IDM is *not* about processes.
 It is all abound data and policies.
@@ -559,7 +559,7 @@ Most likely, you will need both.
 You may need a "sponsor" for each partner or even user.
 Sponsor is your employee/contractor that is responsible for the partner/user.
 
-TODO: Academia, distributed research teams, vitual organizations, all that mess.
+TODO: Academia, distributed research teams, virtual organizations, all that mess.
 
 (Business to Consumer/Customer/Citizen, B2C, CIAM)
 Usually on a bigger scale. Needs scalability.
@@ -576,11 +576,11 @@ It is too much work, too much maintenance.
 Prioritize.
 Automate frequently-used systems (large populations).
 Automate frequently-changed systems (fluctuation).
-Automate sensitive systems (seucirity, accountability).
+Automate sensitive systems (security, accountability).
 Automate day-one systems (mail, productivity).
 Automate systems that generate helpdesk load.
 
-However, think about security and accountibility.
+However, think about security and accountability.
 Semi-manual approach may be a good compromise (CSV exports).
 
 === Password Management
@@ -800,7 +800,7 @@ Direct access to audit database table is usually used to transfer event informat
 
 === Summary of Boundaries
 
-The following table provides summary and clarification of border cases, specifying functionality provided by IGA plarform _vis-à-vis_ functionality of other systems.
+The following table provides summary and clarification of border cases, specifying functionality provided by IGA platform _vis-à-vis_ functionality of other systems.
 
 |===
 | MidPoint functionality | Functionality of other systems

--- a/90-troubleshooting.adoc
+++ b/90-troubleshooting.adoc
@@ -767,7 +767,7 @@ The process usually goes like this:
 There are several ways to do that.
 You can use "preview" operation of user interface to see the input.
 You can examine the operation result in the user interface to see the outcome of the operation, or you may have a look at the audit trail.
-Enabling auditing to a log files may also help.
+Enabling auditing to a log file may also help.
 
 . Have a look at clockwork.
 Clockwork can provide a summary of the operation when `DEBUG` log level on `com.evolveum.midpoint.model.impl.lens.Clockwork` package is enabled.

--- a/90-troubleshooting.adoc
+++ b/90-troubleshooting.adoc
@@ -389,7 +389,7 @@ However, even non-developers can learn how to use the package names efficiently.
 The first thing to keep in mind is that midPoint is composed of subsystems and components.
 Each subsystem and component has its own package name.
 Those can be used to control logging of individual parts of midPoint.
-Following table provides an overview of those architectural blocks.
+The following table provides an overview of those architectural blocks.
 
 |===
 |Subsystem/component |Package name |Description
@@ -660,7 +660,7 @@ For that reason clockwork and projector work in _waves_.
 Therefore, several steps described above may be repeated in each wave.
 Clockwork and projector exchange control in each wave until the operation is done.
 
-Following picture provides a structural view of this setup.
+The following picture provides a structural view of this setup.
 
 image::90-02-lens-provisioning-structure.png[Model and provisioning structure]
 
@@ -1180,7 +1180,7 @@ However, please keep in mind that this is quite intense logging.
 It can easily impact the system performance and flood the logs on a busy system with a lot of authorization.
 It is better to troubleshoot the configuration in a development or testing environment.
 
-When the security logging is enabled then you can see following messages in the logs:
+When the security logging is enabled then you can see the following messages in the logs:
 
 ----
 2017-01-23 14:32:37,824 [main] TRACE (c.e.m.security.impl.SecurityEnforcerImpl): AUTZ: evaluating security constraints principal=MidPointPrincipal(user:c0c010c0-d34d-b33f-f00d-111111111111(jack), autz=[[http://midpoint.evolveum.com/xml/ns/public/security/authorization-model-3#read])]), object=user:c0c010c0-d34d-b33f-f00d-111111111111(jack)
@@ -1408,7 +1408,7 @@ Special e-mail address is provided for responsible disclosure of security-relate
 security@evolveum.com
 ----
 
-Typical bug report contains following information:
+Typical bug report contains the following information:
 
 * What operation have you tried or what do you want to achieve.
 Some "bugs" may be caused by trying to achieve something using the wrong mechanism.

--- a/92-additional-information.adoc
+++ b/92-additional-information.adoc
@@ -49,7 +49,7 @@ Some chapters contain mostly complete configurations of the midPoint deployment.
 These configurations have a separate folder in the midPoint samples.
 Look for a `samples` folder in the github repository in which source code of this books is maintained.
 All the important files used in this book are there, sorted by chapter number.
-There are also special-purpose _docker compose_ configurations that simulate configuratin used in this book.
+There are also special-purpose _docker compose_ configurations that simulate configurations used in this book.
 The _readme_ files in individual directories provide more details.
 
 URL{nbsp}(version{nbsp}{midpointversion}):{nbsp}https://github.com/Evolveum/midpoint-book/tree/support-{midpointversion}/samples[https://github.com/Evolveum/midpoint-book/tree/support-{midpointversion}/samples] +

--- a/98-to-be-continued.adoc
+++ b/98-to-be-continued.adoc
@@ -107,7 +107,7 @@ MidPoint was designed from the day one to be a service-based application.
 Therefore, there is REST services packed with features.
 Actually almost anything that midPoint does can be controlled by using those services.
 
-* *Advanced concepts:* There are still some features that were not explained in previous chapters: consistency mechanisms, personas, multi-connector resources and so on.
+* *Advanced concepts:* There are still some features that were not explained in the previous chapters: consistency mechanisms, personas, multi-connector resources and so on.
 Some of those features are seldom used, but they may save your project.
 Other features are used all the times, but they are a natural part of midPoint and therefore they are almost invisible.
 All those features deserve explanation.
@@ -148,7 +148,7 @@ However, those people are just engineers.
 They need to pay their bills.
 They cannot put away their day-to-day responsibilities to work on this book.
 Obviously, funding is needed to finish the book.
-As this book is available for free there is no direct income that could provide the funding for next chapters.
+As this book is available for free there is no direct income that could provide the funding for additional chapters.
 There is only one way: sponsoring.
 
 If you like this book, then please consider sponsoring some of the next chapters.

--- a/glossary.adoc
+++ b/glossary.adoc
@@ -60,7 +60,7 @@ X.1252 term: access control
 +
 See also: <<glossterm-rbac,Role-Based Access Control>>, <<glossterm-abac,Attribute-Based Access Control>>, <<glossterm-pbac,Policy-Based Access Control>>
 [[glossterm-access-management]]Access Management (AM)::
-Access Management (AM) is a security discipline that provides access to authorised users to enter particular resources. It also prevents non-authorised users from accessing the resources. Thus the goal of Access Management is to unify the security mechanisms that take place when a user is accessing specific system or functionality. Single Sign-On (SSO) is sometimes considered to be a part of Access Management.
+Access Management (AM) is a security discipline that provides access to authorized users to enter particular resources. It also prevents non-authorized users from accessing the resources. Thus the goal of Access Management is to unify the security mechanisms that take place when a user is accessing specific system or functionality. Single Sign-On (SSO) is sometimes considered to be a part of Access Management.
 [[glossterm-access-request]]Access Request Process::
 Access request process is a business process used to request additional access or privileges for information systems and applications. It is usually a semi-manual process. It starts with a user requesting access or privileges for applications. The request is usually routed through approval steps. When approved, the access is provisioned.
 +
@@ -850,7 +850,7 @@ See also: <<glossterm-assignment,Assignment>>, <<glossterm-role,Role>>
 [[glossterm-information-classification]]Information classification::
 
 +
-In midPoint terminology: Information classification is a process in which organisations assess their data and systems, with regard to the necessary level of protection. The information is classified by assigning information _labels_ or _classifications_ to individual assets, such as databases, filesystems, applications or even individual files.
+In midPoint terminology: Information classification is a process in which organizations assess their data and systems, with regard to the necessary level of protection. The information is classified by assigning information _labels_ or _classifications_ to individual assets, such as databases, filesystems, applications or even individual files.
 +
 See also link:https://docs.evolveum.com/midpoint/reference/classification/[more information at docs.evolveum.com].
 +
@@ -990,7 +990,7 @@ X.1252 term: mutual authentication
 +
 See also: <<glossterm-mutual-authentication,Mutual Authentication>>
 [[glossterm-near-miss]]Near miss::
-An event that could have compromised the security of systems, data or services that did not materialise.
+An event that could have compromised the security of systems, data or services that did not materialize.
 +
 See also: <<glossterm-cyberattack,Cyberattack>>, <<glossterm-cybersecurity-incident,Cybersecurity incident>>
 [[glossterm-ngac]]Next Generation Access Control (NGAC)::
@@ -1176,7 +1176,7 @@ Functional component with a responsibility to interpret policy and make decision
 +
 See also: <<glossterm-authorization,Authorization>>, <<glossterm-access-control,Access Control>>, <<glossterm-authorization-service,Authorization Service>>, <<glossterm-pep,Policy Enforcement Point>>, <<glossterm-pap,Policy Administration Point>>, <<glossterm-pip,Policy Information Point>>
 [[glossterm-pdrbac]]Policy-Driven Role-Based Access Control::
-A mechanism for managing of user access to information systems based on a concept of dynamic roles and policies. It is an extension of traditional Role-Based Access Control (RBAC), applying dynamic policies to govern behaviour and assignment of roles. In policy-driven RBAC, roles are no longer static, they contain logic that determines set of privileges given by the role. The user-role assignments are also dynamic, controlled by automatic role assignment policies.
+A mechanism for managing of user access to information systems based on a concept of dynamic roles and policies. It is an extension of traditional Role-Based Access Control (RBAC), applying dynamic policies to govern behavior and assignment of roles. In policy-driven RBAC, roles are no longer static, they contain logic that determines set of privileges given by the role. The user-role assignments are also dynamic, controlled by automatic role assignment policies.
 +
 See also link:https://docs.evolveum.com/midpoint/reference/roles-policies/pdrbac/[more information at docs.evolveum.com].
 +
@@ -1600,7 +1600,7 @@ Alternative terms: Single Log-On
 +
 See also: <<glossterm-authentication,Authentication>>, <<glossterm-identity-provider,Identity Provider>>, <<glossterm-identity-federation,Identity Federation>>
 [[glossterm-standard]]Standard::
-Technical specification, adopted by a recognised standardisation body, for repeated or continuous application, with which compliance is not compulsory.
+Technical specification, adopted by a recognized standardization body, for repeated or continuous application, with which compliance is not compulsory.
 +
 Alternative terms: Technical standard, Technology standard, Official standard
 +

--- a/glossary.adoc
+++ b/glossary.adoc
@@ -1404,7 +1404,7 @@ Requirement is a need or expectation that is stated or implied. Requirements are
 +
 See also: <<glossterm-compliance,Compliance>>
 [[glossterm-residual-risk]]Residual risk::
-Residual risk is a risk that remains after risk treatment. It is a risk that was not eliminated during a cybersecurity activities. As it is practically impossible to eliminate risk completely, some residual risk has to be accepted, as part of the usual cybersecurity program.
+Residual risk is a risk that remains after risk treatment. It is a risk that was not eliminated during cybersecurity activities. As it is practically impossible to eliminate risk completely, some residual risk has to be accepted, as part of the usual cybersecurity program.
 +
 Alternative terms: Retained risk
 +
@@ -1482,7 +1482,7 @@ Risk identification is a process of discovering and describing risks. It involve
 +
 See also: <<glossterm-risk,Risk>>, <<glossterm-risk-assessment,Risk assessment>>
 [[glossterm-risk-level]]Risk level::
-Magnitude or measure of risk. Expression of risk level is heavily influenced by context. Risk levels can be quantitative, expressing risk level in a measurable and generally comparable quantities, such as perceptual probability or weighted monetary cost. Risk levels can also be qualitative, expressing risk level in a relative terms, such as "low", "medium" and "high". Risk levels may consider impact (consequence) or a risk, or it may be concerned solely with probability of a risk occurrence.
+Magnitude or measure of risk. Expression of risk level is heavily influenced by context. Risk levels can be quantitative, expressing risk level in a measurable and generally comparable quantities, such as perceptual probability or weighted monetary cost. Risk levels can also be qualitative, expressing risk level in relative terms, such as "low", "medium" and "high". Risk levels may consider impact (consequence) or a risk, or it may be concerned solely with probability of a risk occurrence.
 +
 Alternative terms: Level of risk
 +
@@ -1580,7 +1580,7 @@ See also: <<glossterm-self-asserted,Self-Asserted>>, <<glossterm-decentralized-i
 [[glossterm-shadow]]Shadow::
 
 +
-In midPoint terminology: Shadow objects are objects in midPoint repository representing objects in identity resources, such as accounts or groups. Shadow objects are used by midPoint as a proxy objects, or data adapters for real accounts, groups or organizational units in identity resources. MidPoint stores identifiers of resource objects in shadow objects, together with meta-data, policy-related information and operational data that relate to the resource object that the shadows represent. The identifiers stored in shadow objects are used to locate the correct resource object even in cases that is renamed or it moves. Shadow objects may contain copies of the data of real resource objects. However, in default configuration, only identifiers are stored in shadow objects.
+In midPoint terminology: Shadow objects are objects in midPoint repository representing objects in identity resources, such as accounts or groups. Shadow objects are used by midPoint as proxy objects, or data adapters for real accounts, groups or organizational units in identity resources. MidPoint stores identifiers of resource objects in shadow objects, together with meta-data, policy-related information and operational data that relate to the resource object that the shadows represent. The identifiers stored in shadow objects are used to locate the correct resource object even in cases that is renamed or it moves. Shadow objects may contain copies of the data of real resource objects. However, in default configuration, only identifiers are stored in shadow objects.
 +
 See also link:https://docs.evolveum.com/midpoint/reference/resources/shadow/[more information at docs.evolveum.com].
 +
@@ -1660,11 +1660,11 @@ X.1252 term: trust
 +
 See also: <<glossterm-triangle-of-trust,Triangle Of Trust>>, <<glossterm-trusted-third-party,Trusted Third Party>>
 [[glossterm-trust-service]]Trust service::
-Electronic service that issues a digital credentials, acting as a trusted third party.
+Electronic service that issues digital credentials, acting as a trusted third party.
 +
 See also: <<glossterm-trusted-third-party,Trusted Third Party>>, <<glossterm-certificate-authority,Certificate Authority>>
 [[glossterm-trusted-third-party]]Trusted Third Party::
-An entity which makes a claims, claims that are trusted by other parties. Usually a central entity in a system that is trusted by many entities. In scenarios involving Triangle of Trust, the issuer is considered to be trusted third party.
+An entity which makes claims, claims that are trusted by other parties. Usually a central entity in a system that is trusted by many entities. In scenarios involving Triangle of Trust, the issuer is considered to be trusted third party.
 +
 X.1252 term: trusted third party
 +

--- a/glossary.adoc
+++ b/glossary.adoc
@@ -40,7 +40,7 @@ Access certification helps with management of access rights. These rights also c
 +
 Certifications are often conducted in a form of certification campaigns, certifying access of many users in each campaign, distributing the work among many reviewers to keep amount of work per person reasonable. Despite that, the overall effort necessary for completion of certification campaign can be huge. Therefore, certification campaigns are being replaced by microcertifications, certifying specific users or privileges on as-needed basis.
 +
-Access certification is often used to address over-provisioning of privileges, in a attempt to maintain the principle of least privilege.
+Access certification is often used to address over-provisioning of privileges, in an attempt to maintain the principle of least privilege.
 +
 Alternative terms: Access Re-certification, Re-certification, Attestation, Access Review
 +
@@ -132,7 +132,7 @@ In midPoint terminology: An object that can hold assignments. Assignment holder 
 +
 See also: <<glossterm-assignment,Assignment>>, <<glossterm-focus,Focus>>
 [[glossterm-audit]]Audit::
-Audit is an systematic and documented process for reviewing specific processes, organizations or regulatory compliance. It involves obtaining and objective processing of evidence, including evidence stored in special-purpose audit trails. Audit can be internal, conducted by an organization, reviewing its own processes or compliance. It can also be external, conducted by an independent trusted party.
+Audit is a systematic and documented process for reviewing specific processes, organizations or regulatory compliance. It involves obtaining and objective processing of evidence, including evidence stored in special-purpose audit trails. Audit can be internal, conducted by an organization, reviewing its own processes or compliance. It can also be external, conducted by an independent trusted party.
 +
 See also: <<glossterm-audit-trail,Audit trail>>
 [[glossterm-audit-scope]]Audit scope::
@@ -284,7 +284,7 @@ Control is a measure that affects risk. Controls are used in security management
 +
 Alternative terms: Countermeasure, Cybersecurity measure, Measure
 [[glossterm-control-objective]]Control objective::
-Control objective is an intended effect of an control. It is a description of the effect that a control should have when implemented.
+Control objective is an intended effect of a control. It is a description of the effect that a control should have when implemented.
 +
 See also: <<glossterm-control,Control>>
 [[glossterm-corrective-action]]Corrective action::
@@ -322,7 +322,7 @@ Cross-domain techniques employ special mechanism to protect the information, or 
 +
 See also: <<glossterm-domain,Domain>>, <<glossterm-identity-provider,Identity Provider>>, <<glossterm-relying-party,Relying Party>>, <<glossterm-identity-federation,Identity Federation>>
 [[glossterm-cyberattack]]Cyberattack::
-Cyberattack is a an intentional effort to steal, destroy, expose, alter, disable or gain unauthorized access to information systems and data (information asset). Cyberattack is a cybersecurity breach.
+Cyberattack is an intentional effort to steal, destroy, expose, alter, disable or gain unauthorized access to information systems and data (information asset). Cyberattack is a cybersecurity breach.
 +
 Alternative terms: Cyber attack
 +
@@ -334,7 +334,7 @@ Alternative terms: Information security
 +
 See also: <<glossterm-cybersecurity-governance,Cybersecurity governance>>, <<glossterm-cyberattack,Cyberattack>>, <<glossterm-risk-based-approach,Risk-based approach>>
 [[glossterm-cybersecurity-event]]Cybersecurity event::
-Cybersecurity event is a event affecting cybersecurity of an organization. It is an occurrence of system, service or network state, indicating possible breach of information security.
+Cybersecurity event is an event affecting cybersecurity of an organization. It is an occurrence of system, service or network state, indicating possible breach of information security.
 +
 Alternative terms: Information security event
 +
@@ -642,7 +642,7 @@ X.1252 term: claim
 +
 See also: <<glossterm-digital-identity-attribute,Digital Identity Attribute>>, <<glossterm-identity-provider,Identity Provider>>, <<glossterm-relying-party,Relying Party>>
 [[glossterm-identity-based-security]]Identity-based Security::
-Identity-based security is a approach to cybersecurity, focused on concept of identity. It places identities in the center of cybersecurity mind-set, adjusting cybersecurity design and practices around identities. Identity-based security is concerned with the identity that initiates an action, or identity that is responsible for an action, object or configuration. Simply speaking, identity-based security tries to make sure that access to service or information is provided to a specific identity, and only to the identity that is entitled for such access. Identity-based security is not limited to identity of persons. Identities of machines, services, devices, networks and similar technological and virtual concepts (non-human identities, NHI) are included as well.
+Identity-based security is an approach to cybersecurity, focused on concept of identity. It places identities in the center of cybersecurity mind-set, adjusting cybersecurity design and practices around identities. Identity-based security is concerned with the identity that initiates an action, or identity that is responsible for an action, object or configuration. Simply speaking, identity-based security tries to make sure that access to service or information is provided to a specific identity, and only to the identity that is entitled for such access. Identity-based security is not limited to identity of persons. Identities of machines, services, devices, networks and similar technological and virtual concepts (non-human identities, NHI) are included as well.
 +
 Identity-based security relies on dynamic policies based on the identity of the actor, as well as context of the operation or situation. Unlike traditional approaches, identity-based security is not fixed, it does not assume static world where an operation is allowed once and for all, and stays allowed for ever. Policies in identity-based security are dynamic, they are meant to be continuously applied, maintained, reviewed and improved, dynamically adapting to the environment and requirements.
 +
@@ -816,7 +816,7 @@ See also: <<glossterm-enrollment,Enrollment>>, <<glossterm-onboarding,Onboarding
 [[glossterm-identity-resource]]Identity Resource::
 In IAM field, a Resource is usually a network-accessible asset capable of managing identity information.
 +
-In midPoint terminology: An Resource is a system that is either identity data source or provisioning target. IDM system (midPoint) is managing accounts in that system, feeding data from that system or doing any other combination of identity management operations. Identity resource should not be confused with "web resource" that is used by RESTful APIs.
+In midPoint terminology: A Resource is a system that is either identity data source or provisioning target. IDM system (midPoint) is managing accounts in that system, feeding data from that system or doing any other combination of identity management operations. Identity resource should not be confused with "web resource" that is used by RESTful APIs.
 +
 Alternative terms: Provisioning Resource, Resource
 +
@@ -1110,7 +1110,7 @@ A mechanism for managing of user access to information systems based on policy. 
 +
 PBAC seems to be technically equivalent to ABAC. However, in contrast to ABAC, PBAC is supposed to contain "policy management" layer, which is not clearly defined either.
 +
-Overall, PBAC is an conceptual idea rather than a concrete access control model. It is still in early stages of development.
+Overall, PBAC is a conceptual idea rather than a concrete access control model. It is still in early stages of development.
 +
 Alternative terms: Dynamic Authorization Management, Policy as Code
 +
@@ -1288,7 +1288,7 @@ See also link:https://docs.evolveum.com/midpoint/reference/schema/focus-and-proj
 +
 See also: <<glossterm-shadow,Shadow>>, <<glossterm-focus,Focus>>, <<glossterm-assignment,Assignment>>
 [[glossterm-prp]]Policy Retrieval Point (PRP)::
-Functional component with a responsibility to store and distribute policies for use by policy decision points (PDP). PRP acts as an repository for policy. The policy is usually stored persistently at PRP, e.g. in a form of a file or database. Primary responsibility of PRP is to make policy available to policy decision points (PDP), either by "pull" (PDP retrieving the policy from PRP) or by "push" (PRP sending the policy to PDP). PRP is instrumental in enabling distributed architecture with several PDPs.
+Functional component with a responsibility to store and distribute policies for use by policy decision points (PDP). PRP acts as a repository for policy. The policy is usually stored persistently at PRP, e.g. in a form of a file or database. Primary responsibility of PRP is to make policy available to policy decision points (PDP), either by "pull" (PDP retrieving the policy from PRP) or by "push" (PRP sending the policy to PDP). PRP is instrumental in enabling distributed architecture with several PDPs.
 +
 Note: PRP is only storing and distributing the policy, it is not responsible for policy creation or management. Policy management is responsibility of policy administration point (PAP).
 +
@@ -1706,7 +1706,7 @@ X.1252 term: verification
 +
 See also: <<glossterm-verifier,Verifier>>, <<glossterm-digital-identity-attribute,Digital Identity Attribute>>, <<glossterm-schema,Schema>>, <<glossterm-referential-integrity,Referential Integrity>>
 [[glossterm-verifier]]Verifier::
-Entity that performs verification, usually a verification of an credential or a claim. In Triangle of Trust scenarios, the verifier verifies credentials/claims provided by the holder. Verifier may need information provided by the issuer of credential/claim to be able to complete the verification process.
+Entity that performs verification, usually a verification of a credential or a claim. In Triangle of Trust scenarios, the verifier verifies credentials/claims provided by the holder. Verifier may need information provided by the issuer of credential/claim to be able to complete the verification process.
 +
 ISO 24760 term: verifier
 +

--- a/glossary.adoc
+++ b/glossary.adoc
@@ -30,7 +30,7 @@ See also: <<glossterm-access-control,Access Control>>
 [[glossterm-abstract-role]]Abstract Role::
 
 +
-In midPoint terminology: Abstract role means any type of object that acts as a role. This means that abstract tole can be used to hold inducements, which give privileges to other objects. Role, org, service, archetype are abstract roles in midPoint.
+In midPoint terminology: Abstract role means any type of object that acts as a role. This means that abstract role can be used to hold inducements, which give privileges to other objects. Role, org, service, archetype are abstract roles in midPoint.
 +
 See also link:https://docs.evolveum.com/midpoint/architecture/concepts/abstract-role/[more information at docs.evolveum.com].
 +
@@ -128,7 +128,7 @@ See also: <<glossterm-inducement,Inducement>>, <<glossterm-assignment-holder,Ass
 [[glossterm-assignment-holder]]Assignment Holder::
 
 +
-In midPoint terminology: An object that can hold assignments. Assignment holder can be considered a "source" of an assignment, a source of a relation that an assignmnt represents. Almost all object types in midPoint are assignment holder, capable of containing an assignment.
+In midPoint terminology: An object that can hold assignments. Assignment holder can be considered a "source" of an assignment, a source of a relation that an assignment represents. Almost all object types in midPoint are assignment holder, capable of containing an assignment.
 +
 See also: <<glossterm-assignment,Assignment>>, <<glossterm-focus,Focus>>
 [[glossterm-audit]]Audit::
@@ -346,7 +346,7 @@ Alternative terms: Information security governance
 +
 See also: <<glossterm-cybersecurity,Cybersecurity>>, <<glossterm-isms,Information security management system>>, <<glossterm-cybersecurity-resilience,Cybersecurity resilience>>, <<glossterm-risk-management,Risk management>>
 [[glossterm-cybersecurity-incident]]Cybersecurity incident::
-Cybersecurity incident is unwanted or unexpected cybersecurity event, impacting cybersecurity of an organization. Cyberattack is the usual type of cybersecurity incidents. Cybersecurity incidents include situations, where security breach cannot be proven, however there is a siginificant probability that security of information and systems might have been affected.
+Cybersecurity incident is unwanted or unexpected cybersecurity event, impacting cybersecurity of an organization. Cyberattack is the usual type of cybersecurity incidents. Cybersecurity incidents include situations, where security breach cannot be proven, however there is a significant probability that security of information and systems might have been affected.
 +
 Alternative terms: Information security incident, Incident
 +
@@ -668,7 +668,7 @@ Alternative terms: Connector
 +
 See also: <<glossterm-identity-connector-framework,Identity Connector Framework>>, <<glossterm-connid,ConnId>>
 [[glossterm-identity-connector-framework]]Identity Connector Framework::
-Generally speaking, a programing framework (library) for creating and managing identity connectors. However, this rather generic term often refers to the Identity Connector Framework (ICF), originally developed by Sun Microsystem in 2000s. The ICF was releases as an open source project by Sun, only to be later abandoned after Sun-Oracle merger. The ICF was a base for several forks, including ConnId and OpenICF.
+Generally speaking, a programming framework (library) for creating and managing identity connectors. However, this rather generic term often refers to the Identity Connector Framework (ICF), originally developed by Sun Microsystems in 2000s. The ICF was releases as an open source project by Sun, only to be later abandoned after Sun-Oracle merger. The ICF was a base for several forks, including ConnId and OpenICF.
 +
 Alternative terms: Connector Framework, ICF
 +
@@ -948,7 +948,7 @@ Alternative terms: Management system
 +
 See also: <<glossterm-isms,Information security management system>>, <<glossterm-identity-management,Identity Management>>, <<glossterm-cybersecurity-governance,Cybersecurity governance>>
 [[glossterm-manual-fulfillment]]Manual Fulfillment::
-Manual process of creating, updating and deleting accounts, entitlements and similar objects, driven by identity management system, but exexcuted by human operator. Manual fulfillment is initiated by an identity management system, usually as a consequence of change in user privileges or policies. Identity management system creates a ticket for system administrators, containing instructions to create/modify/delete an acccount or entitlement in a specific information system. Actual action is executed manually, by the system administrator. Manual fulfillment is used for systems, for which automatic identity connector is not available.
+Manual process of creating, updating and deleting accounts, entitlements and similar objects, driven by identity management system, but executed by human operator. Manual fulfillment is initiated by an identity management system, usually as a consequence of change in user privileges or policies. Identity management system creates a ticket for system administrators, containing instructions to create/modify/delete an account or entitlement in a specific information system. Actual action is executed manually, by the system administrator. Manual fulfillment is used for systems, for which automatic identity connector is not available.
 +
 Alternative terms: Manual Provisioning/deprovisioning, Manual resource, Manual connector
 +
@@ -998,7 +998,7 @@ A graph-based mechanism for managing of user access to information systems. NGAC
 +
 See also: <<glossterm-access-control,Access Control>>, <<glossterm-rebac,Relationship-Based Access Control>>
 [[glossterm-non-compliance]]Non-compliance::
-State of non-fulfilment of a requirement, such as violation of a requirement stated in a policy, regulation or standard.
+State of non-fulfillment of a requirement, such as violation of a requirement stated in a policy, regulation or standard.
 +
 Alternative terms: Noncompliance, Nonconformity, Violation
 [[glossterm-non-repudiation]]Non-repudiation::
@@ -1080,7 +1080,7 @@ Passkey is a type of strong digital credential. They are used to authenticate a 
 +
 See also: <<glossterm-credential,Credential>>, <<glossterm-pin,Personal identification number>>
 [[glossterm-password]]Password::
-Password is a type of (usualy weak) digital credential, meant to be secret, known only to a single user. Passwords are memorized secret authenticators, usually selected by users, meant to be remembered. Therefore, they are often short strings in a human-friendly form, such as simple words or names. Simplicity of passwords makes them vulnerable to dictionary attacks. Recently, passwords are randomly generated, managed by password management applications. However, even randomly-generated passwords may still be vulnerable to phishing attacks. Therefore organizations are moving towards authentication methods that do not depend on passwords (e.g. passkeys), or enroll multi-factor authentication schemes.
+Password is a type of (usually weak) digital credential, meant to be secret, known only to a single user. Passwords are memorized secret authenticators, usually selected by users, meant to be remembered. Therefore, they are often short strings in a human-friendly form, such as simple words or names. Simplicity of passwords makes them vulnerable to dictionary attacks. Recently, passwords are randomly generated, managed by password management applications. However, even randomly-generated passwords may still be vulnerable to phishing attacks. Therefore organizations are moving towards authentication methods that do not depend on passwords (e.g. passkeys), or enroll multi-factor authentication schemes.
 +
 Alternative terms: Passcode
 +
@@ -1092,7 +1092,7 @@ Alternative terms: Passwordless
 +
 See also: <<glossterm-authentication,Authentication>>, <<glossterm-password,Password>>, <<glossterm-passkey,Passkey>>, <<glossterm-mfa,Multi-factor authentication>>
 [[glossterm-password-policy]]Password policy::
-Password policy constraints the selection and use of passwords with an aim to make them more secure. It almost always sets requirements for password complexity, such as minimal length of passwords and characted classes used in the password (e.g. letters, numbers, punctuation). Password policies often specify constraints on password lifetime, such as password expiration intervals.
+Password policy constraints the selection and use of passwords with an aim to make them more secure. It almost always sets requirements for password complexity, such as minimal length of passwords and character classes used in the password (e.g. letters, numbers, punctuation). Password policies often specify constraints on password lifetime, such as password expiration intervals.
 +
 Alternative terms: Password complexity policy
 +

--- a/glossary.adoc
+++ b/glossary.adoc
@@ -994,7 +994,7 @@ An event that could have compromised the security of systems, data or services t
 +
 See also: <<glossterm-cyberattack,Cyberattack>>, <<glossterm-cybersecurity-incident,Cybersecurity incident>>
 [[glossterm-ngac]]Next Generation Access Control (NGAC)::
-A graph-based mechanism for managing of user access to information systems. NGAC specifies directed acyclic graph for user and concepts related to them (e.g. organizational units), and a separate directed acyclic graph for objects and and concepts related to them (e.g. folders). Access control decisions are reached by evaluating the two directed acyclic graphs with respect to policy classes, and operations specified as relations between the graphs. NGAC is specified in NIST publications (e.g. INCITS 499: Information technology - Next Generation Access Control - Functional Architecture)
+A graph-based mechanism for managing of user access to information systems. NGAC specifies directed acyclic graph for user and concepts related to them (e.g. organizational units), and a separate directed acyclic graph for objects and concepts related to them (e.g. folders). Access control decisions are reached by evaluating the two directed acyclic graphs with respect to policy classes, and operations specified as relations between the graphs. NGAC is specified in NIST publications (e.g. INCITS 499: Information technology - Next Generation Access Control - Functional Architecture)
 +
 See also: <<glossterm-access-control,Access Control>>, <<glossterm-rebac,Relationship-Based Access Control>>
 [[glossterm-non-compliance]]Non-compliance::

--- a/samples/docker/10/README.adoc
+++ b/samples/docker/10/README.adoc
@@ -14,7 +14,7 @@ All data will be lost.
 
 The initial state corresponds roughly to the end of chapter 10 (Organizational Structure) of the book.
 
-Following steps can be used to fully initialize the configuration:
+The following steps can be used to fully initialize the configuration:
 
 . Start/resume `LDAP Reconciliation` task.
 

--- a/samples/docker/5/README.adoc
+++ b/samples/docker/5/README.adoc
@@ -15,7 +15,7 @@ All data will be lost.
 The initial state corresponds roughly to the beginning of chapter 5 (Synchronization) of the book.
 However, the resources are pre-configured for later chapters (e.g. job codes, org units)
 
-Following steps can be used to proceed to state for later chapters:
+The following steps can be used to proceed to state for later chapters:
 
 . Start/resume `LDAP Reconciliation` task.
 


### PR DESCRIPTION
This fixes some of the most say annoying/screaming typos throughout the book. See individual commit messages for details.

If you're interested, I can also try to prepare another batch of fixes for the remaining tens (around 100 to 200?) of mistakes which are not that easily categorizable or fixable. I believe that if all these mistakes get fixed, readability of this otherwise great book would increase quite a bit.